### PR TITLE
feat: add color-scheme.json template

### DIFF
--- a/templates/json-scheme.json
+++ b/templates/json-scheme.json
@@ -1,0 +1,24 @@
+{
+  "name": "GVCCI Color Scheme",
+  "author": "",
+  "color": [
+    "{{ansi-black-normal-hex}}",
+    "{{ansi-red-normal-hex}}",
+    "{{ansi-green-normal-hex}}",
+    "{{ansi-yellow-normal-hex}}",
+    "{{ansi-blue-normal-hex}}",
+    "{{ansi-magenta-normal-hex}}",
+    "{{ansi-cyan-normal-hex}}",
+    "{{ansi-white-normal-hex}}",
+    "{{ansi-black-bright-hex}}",
+    "{{ansi-red-bright-hex}}",
+    "{{ansi-green-bright-hex}}",
+    "{{ansi-yellow-bright-hex}}",
+    "{{ansi-blue-bright-hex}}",
+    "{{ansi-magenta-bright-hex}}",
+    "{{ansi-cyan-bright-hex}}",
+    "{{ansi-white-bright-hex}}"
+  ],
+  "foreground": "{{foreground-hex}}",
+  "background": "{{background-hex}}"
+}


### PR DESCRIPTION
Thank you for making this! I had been looking for something like it for ages.

This commit introduces support for the `color-scheme.json` format seen on
http://terminal.sexy and used by [WPGTK](https://github.com/deviantfero/wpgtk)